### PR TITLE
AtCoder新サイトに対応

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 ![サンプル画像](https://imgur.com/9T2Tg7W.png)
 
 * ↑のような感じで、AtCoderの質問(Clarification)が来たらSlackに通知します。
-* owner権限を持っている前提のコンテスト管理者用のツールのため、コンテスタントだと使えません。
-* AtCoder Beta版には対応していません。
+* Manager権限を持っている前提のコンテスト管理者用のツールのため、Contestantだと使えません。
+* 旧サイト(`https://xxx.contest.atcoder.jp`)の廃止に伴い、新サイト(`https://atcoder.jp/contests/xxx`)に対応しました。
 
 ## 使い方
 
@@ -19,7 +19,7 @@ cp config_sample config
 2. configファイルを以下の例に従って編集。
 
 ```
-CONTEST_URL=https://jag2017autumn.contest.atcoder.jp           # クラー通知したいコンテストのURL(Beta版には対応していません)
+CONTEST_URL=https://atcoder.jp/contests/jag2017autumn/         # クラー通知したいコンテストのURL
 ATCODER_ID=username                                            # コンテストの管理権限を所持しているユーザのID
 ATCODER_PASS=password                                          # ユーザのパスワード
 SLACK_HOOK_URL=https://hooks.slack.com/services/XXXX/XXXX/XXXX # slackのincoming webhook url ※1

--- a/config_sample
+++ b/config_sample
@@ -1,4 +1,4 @@
-CONTEST_URL=https://hogehoge.contest.atcoder.jp
+CONTEST_URL=https://atcoder.jp/contests/<contest_name>/
 ATCODER_ID=
 ATCODER_PASS=
 SLACK_HOOK_URL=

--- a/login.sh
+++ b/login.sh
@@ -1,3 +1,5 @@
 set -e
 source ./config
-curl -c ./cookiejar -F "name=${ATCODER_ID}" -F "password=${ATCODER_PASS}" "${CONTEST_URL}/login"
+LOGIN_URL='https://atcoder.jp/login'
+CSRF_TOKEN=$(curl -c ./cookiejar -s ${LOGIN_URL} | grep 'csrfToken' | cut -f 2 -d '"')
+curl -b ./cookiejar -c ./cookiejar -X POST -F "csrf_token=${CSRF_TOKEN}" -F "username=${ATCODER_ID}" -F "password=${ATCODER_PASS}" "${LOGIN_URL}"

--- a/main.sh
+++ b/main.sh
@@ -1,7 +1,7 @@
 set -e
 source ./config
-curl -s -b ./cookiejar "${CONTEST_URL}/clarifications" > ./clar.html
-python3 ./read_clar.py ./clar.html ${CONTEST_URL} ./clar1.json
+curl -s -b ./cookiejar "${CONTEST_URL%/}/clarifications" > ./clar.html
+python3 ./read_clar.py ./clar.html ./clar1.json
 if [[ -e ./clar0.json ]]; then
   python3 ./diff_clar.py ./clar0.json ./clar1.json ./slack.sh
 fi


### PR DESCRIPTION
## 概要
これまで、AtCoderのコンテストページには`https://<contest-name>.contest.atcoder.jp` のようなURLの旧サイトと、`https://atcoder.jp/contests/<contest-name>/`のようなURLの新サイト（昔でいうところのβ版？）の2つが存在していました。
しかし、いつの間にか前者は廃止されていました。
現在のatcoder-clar2slackは前者にのみ対応しているため、後者のみに対応するように変更しました。
動作確認済みです。

## 詳細
- ログイン処理
  - 認証時にCSRF tokenを送信する必要があり、これに対応しました。
- clar.htmlのparse
  - 色々と少しずつ変わっていたので対応しました。
  - read_clar.pyでCONTEST_URLを使う必要がなくなったため、消しました。